### PR TITLE
feat: implement server API for real time system status and reconnaissance data retrieval

### DIFF
--- a/src/server_api.c
+++ b/src/server_api.c
@@ -386,27 +386,27 @@ static esp_err_t api_admin_set_ap_settings(ws_frame_req_t *req)
 
     char ssid[32] = {0};
     char password[64] = {0};
-    int channel = 1;
-    wifi_phy_rate_t tx_rate = DEFAULT_WIFI_TX_RATE;
 
     if (cJSON_IsString(j_ssid)) {
+        if (strlen(j_ssid->valuestring) == 0 || strlen(j_ssid->valuestring) >= 32) {
+            cJSON_Delete(json);
+            api_send_status_frame(req, "error", "Invalid SSID length.");
+            return ESP_FAIL;
+        }
         strlcpy(ssid, j_ssid->valuestring, sizeof(ssid));
+        save_string_to_nvs(WIFI_SSID_KEY, (const char *)ssid);
     }
     if (cJSON_IsString(j_password)) {
         strlcpy(password, j_password->valuestring, sizeof(password));
+        save_string_to_nvs(WIFI_PASS_KEY, (const char *)password);
     }
     if (cJSON_IsNumber(j_channel)) {
-        channel = j_channel->valueint;
+        save_int_to_nvs(WIFI_CHAN_KEY, j_channel->valueint);
     }
     if (cJSON_IsNumber(j_tx_rate)) {
-        tx_rate = (wifi_phy_rate_t)j_tx_rate->valueint;
+        save_int_to_nvs(WIFI_TX_RATE_KEY, (int32_t)j_tx_rate->valueint);
     }
     cJSON_Delete(json);
-
-    save_string_to_nvs(WIFI_SSID_KEY, (const char *)ssid);
-    save_string_to_nvs(WIFI_PASS_KEY, (const char *)password);
-    save_int_to_nvs(WIFI_CHAN_KEY, channel);
-    save_int_to_nvs(WIFI_TX_RATE_KEY, (int32_t)tx_rate);
 
     api_send_status_frame(req, "ok", "AP settings saved successfully.");
 


### PR DESCRIPTION
# Fix: Empty SSID Bootloop Vulnerability

## Summary of Changes

In `src/server_api.c`, the function `api_admin_set_ap_settings` did not validate the length of the new SSID sent by the client. If a user provided an empty string (or if the payload was manipulated), the backend would blindly save this empty string to the ESP32's Non-Volatile Storage (NVS).

During the next reboot, `wifiMng.c` would retrieve this empty string and pass it to `esp_wifi_set_config()`. Because the ESP-IDF API strictly forbids 0-length SSIDs for AP mode, the `ESP_ERROR_CHECK` macro would trigger a kernel panic, resulting in an infinite bootloop that completely bricks the web interface until a serial flash/NVS erase is performed.

I have updated the code to prevent this bug.

## Code Changes Made

#### `src/server_api.c`
- Added length validation to the SSID field (`strlen(j_ssid->valuestring) == 0 || strlen(j_ssid->valuestring) >= 32`).
- If the SSID length is invalid, the server immediately returns an `ESP_FAIL` alongside an error message to the client WebSocket, safely aborting the operation.
- Refactored the NVS saving logic. Now, configuration fields (`ssid`, `password`, `channel`, `tx_rate`) are *only* written to the NVS if they were valid and explicitly provided in the payload, preventing accidental data overrides.

> [!TIP]
> This fix ensures that the system is significantly more robust against invalid or manipulated UI inputs, and eliminates a guaranteed device bricking scenario.

## Test

1. **Deploy to Device**: Flash the updated firmware to your ESP32.
2. **Access the Web Interface**: Go to the "Configuration" menu.
3. **Empty SSID Test**: Erase the "Management AP SSID" field and click "SAVE & REBOOT".
4. **Expected Result**: A UI notification should display an error ("Invalid SSID length") and the device will not reboot. 
5. **Verify Stability**: Reboot the ESP32 manually to ensure it still successfully boots using the previous valid SSID configuration.
