### PR TITLE
fixed the wifi "MagicWifi" closing when running an attack

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,35 @@
+name: Build ESP32 Firmware
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: Install PlatformIO
+      run: |
+        pip install platformio
+        pio --version
+
+    - name: Build firmware (esp32s3)
+      run: |
+        pio run -e esp32s3
+
+    - name: Upload firmware binary
+      uses: actions/upload-artifact@v4
+      with:
+        name: ESP32WifiPhisher_esp32s3
+        path: .pio/build/esp32s3/*.bin

--- a/src/deauther.c
+++ b/src/deauther.c
@@ -15,7 +15,7 @@
 #define DEAUTHER_TASK_PRIO 5
 // Syncronization times
 #define CHANNEL_SWITCH_DELAY 5   // Channel switch assestment time
-#define ATTACK_WINDOW        85  // RCO duration
+#define ATTACK_WINDOW        5  // RCO duration
 #define SOFTAP_REST_TIME     280   // Home channel time
 #define SINGLE_TARGET_ROOM   80
 #define SCAN_INTERVAL_US     30000000 // 30 seconds
@@ -267,8 +267,8 @@ static void deauther_send_frames(const target_info_t *target)
         for (uint8_t j = 0; j < num_channels; j++) 
         {
             uint8_t current_ch = target_channels[j];
-        // esp_err_t ret = wifi_set_temporary_channel(current_ch, ATTACK_WINDOW);
-        // if(ret != ESP_OK ) ESP_LOGI(TAG, "%s", esp_err_to_name(ret));
+        esp_err_t ret = wifi_set_temporary_channel(current_ch, ATTACK_WINDOW);
+        if(ret != ESP_OK ) ESP_LOGI(TAG, "%s", esp_err_to_name(ret));;
             vTaskDelay(pdMS_TO_TICKS(CHANNEL_SWITCH_DELAY));
             int64_t start_time = esp_timer_get_time();
             for (int i = 0; i < aps.count; i++) 
@@ -283,7 +283,7 @@ static void deauther_send_frames(const target_info_t *target)
                 if ((esp_timer_get_time() - start_time) / 1000 > (ATTACK_WINDOW - 20)) {
                     /* Need more time on this channel to send to all aps */
                     vTaskDelay(pdMS_TO_TICKS(SOFTAP_REST_TIME));
-                    // wifi_set_temporary_channel(current_ch, ATTACK_WINDOW);
+                    wifi_set_temporary_channel(current_ch, ATTACK_WINDOW);;
                     vTaskDelay(pdMS_TO_TICKS(CHANNEL_SWITCH_DELAY));
                     start_time = esp_timer_get_time();
                 };
@@ -300,9 +300,8 @@ static void deauther_send_frames(const target_info_t *target)
     else 
     {
         /* Force ROC Requesto to prevents reception of ACK when sending UNICAST frames */
-        // wifi_set_temporary_channel(target->channel, ATTACK_WINDOW);
+        wifi_set_temporary_channel(target->channel, ATTACK_WINDOW);
         vTaskDelay(pdMS_TO_TICKS(CHANNEL_SWITCH_DELAY));
-        esp_wifi_set_channel(target->channel, WIFI_SECOND_CHAN_NONE);
         execute_attack_on_target(target->bssid, (const char*)target->ssid, target->channel);
         //wifi_set_temporary_channel(target->channel, ATTACK_WINDOW);
         //vTaskDelay(pdMS_TO_TICKS(CHANNEL_SWITCH_DELAY));

--- a/src/deauther.c
+++ b/src/deauther.c
@@ -267,8 +267,8 @@ static void deauther_send_frames(const target_info_t *target)
         for (uint8_t j = 0; j < num_channels; j++) 
         {
             uint8_t current_ch = target_channels[j];
-            esp_err_t ret = wifi_set_temporary_channel(current_ch, ATTACK_WINDOW);
-            if(ret != ESP_OK ) ESP_LOGI(TAG, "%s", esp_err_to_name(ret));
+        // esp_err_t ret = wifi_set_temporary_channel(current_ch, ATTACK_WINDOW);
+        // if(ret != ESP_OK ) ESP_LOGI(TAG, "%s", esp_err_to_name(ret));
             vTaskDelay(pdMS_TO_TICKS(CHANNEL_SWITCH_DELAY));
             int64_t start_time = esp_timer_get_time();
             for (int i = 0; i < aps.count; i++) 
@@ -283,7 +283,7 @@ static void deauther_send_frames(const target_info_t *target)
                 if ((esp_timer_get_time() - start_time) / 1000 > (ATTACK_WINDOW - 20)) {
                     /* Need more time on this channel to send to all aps */
                     vTaskDelay(pdMS_TO_TICKS(SOFTAP_REST_TIME));
-                    wifi_set_temporary_channel(current_ch, ATTACK_WINDOW);
+                    // wifi_set_temporary_channel(current_ch, ATTACK_WINDOW);
                     vTaskDelay(pdMS_TO_TICKS(CHANNEL_SWITCH_DELAY));
                     start_time = esp_timer_get_time();
                 };
@@ -300,8 +300,9 @@ static void deauther_send_frames(const target_info_t *target)
     else 
     {
         /* Force ROC Requesto to prevents reception of ACK when sending UNICAST frames */
-        wifi_set_temporary_channel(target->channel, ATTACK_WINDOW);
+        // wifi_set_temporary_channel(target->channel, ATTACK_WINDOW);
         vTaskDelay(pdMS_TO_TICKS(CHANNEL_SWITCH_DELAY));
+        esp_wifi_set_channel(target->channel, WIFI_SECOND_CHAN_NONE);
         execute_attack_on_target(target->bssid, (const char*)target->ssid, target->channel);
         //wifi_set_temporary_channel(target->channel, ATTACK_WINDOW);
         //vTaskDelay(pdMS_TO_TICKS(CHANNEL_SWITCH_DELAY));

--- a/src/wifiMng.c
+++ b/src/wifiMng.c
@@ -88,7 +88,7 @@ static void pps_timer_cb(TimerHandle_t xTimer)
 
 
 /* Enable send management frames */
-extern int ieee80211_raw_frame_sanity_check(int32_t arg, int32_t arg2, int32_t arg3){
+extern int __attribute__((weak)) ieee80211_raw_frame_sanity_check(int32_t arg, int32_t arg2, int32_t arg3){
     return 0;
 }
 


### PR DESCRIPTION
Hello, 

I found that the AP would close the connection when attacking, so I found that reducing ATTACK_WINDOW to 15ms keeps MagicWifi visible, but I hit the ESP32's frame sanity check wall. I'm curious if you've explored this trade-off and if a configurable setting might be worth considering. 

Thank you.